### PR TITLE
add alias for rake db:migrate

### DIFF
--- a/dotfiles/.aliases
+++ b/dotfiles/.aliases
@@ -39,3 +39,4 @@ alias update='sudo softwareupdate -i -a; brew update; brew upgrade; brew cleanup
 # Kill all the tabs in Chrome to free up memory
 # [C] explained: http://www.commandlinefu.com/commands/view/402/exclude-grep-from-your-grepped-output-of-ps-alias-included-in-description
 alias chromekill="ps ux | grep '[C]hrome Helper --type=renderer' | grep -v extension-process | tr -s ' ' | cut -d ' ' -f2 | xargs kill"
+alias rdm='bundle exec rake db:migrate && git checkout db/schema.rb && RAILS_ENV=test bundle exec rake db:drop && RAILS_ENV=test bundle exec rake db:create  && RAILS_ENV=test bundle exec rake db:schema:load && RAILS_ENV=test bundle exec rake db:migrate'


### PR DESCRIPTION
this alias will migrate dev database, then load the schema on test db, migrate, and dump... this is done to keep a consistent copy of schema.rb